### PR TITLE
Bump org.apache.poi:poi-ooxml

### DIFF
--- a/BACKUPS/BACKUP-14MAY2025/others/code/springboot-kubernetes/03-notifications-service/pom.xml
+++ b/BACKUPS/BACKUP-14MAY2025/others/code/springboot-kubernetes/03-notifications-service/pom.xml
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-ooxml</artifactId>
-			<version>3.15</version>
+			<version>5.4.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bumps org.apache.poi:poi-ooxml from 3.15 to 5.4.0.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi-ooxml dependency-version: 5.4.0 dependency-type: direct:production ...